### PR TITLE
Filtra ETF per Nome, ISIN e ticker

### DIFF
--- a/PortfolioPilot.py
+++ b/PortfolioPilot.py
@@ -101,7 +101,7 @@ def create_layout(asset_df, initial_table_data):
             # Riga di Selezione: Dropdown ETF e Slider Percentuale
             dbc.Row([
                 dbc.Col([
-                    dbc.Label("Seleziona un ETF (Scrivi il nome completo):", style={'color': '#000000'}),
+                    dbc.Label("Seleziona un ETF (Nome, ISIN, Ticker):", style={'color': '#000000'}),
                     dcc.Dropdown(
                         id='etf-dropdown',
                         placeholder="Seleziona un ETF",


### PR DESCRIPTION
Permette di filtrare gli ETF per nome, isin e ticker.

Ciao Dani,
ho seguito la live ieri con il prof e mi ha incuriosito il tuo tool. Ho provato a usarlo oggi e ho visto che la ricerca funziona solo per Nome del fondo ETF. Ho fatto qualche piccola modifica in modo che sia possibile filtrare anche per ISIN e Ticker.